### PR TITLE
fix(mcp): Fix the issue where fetching a single server configuration …

### DIFF
--- a/src/common/mcp.py
+++ b/src/common/mcp.py
@@ -53,7 +53,7 @@ async def get_mcp_tools(server_name: str) -> List[Callable[..., Any]]:
         return _mcp_tools_cache[server_name]
 
     try:
-        client = await get_mcp_client()
+        client = await get_mcp_client({server_name: MCP_SERVERS[server_name]})
         if client is None:
             _mcp_tools_cache[server_name] = []
             return []


### PR DESCRIPTION
The original code logic did not implement the filtering process after obtaining a single Server tool. The filtered Server Name should be passed to MultiServerMCPClient for screening.

Text scripts:

```python
"""Test MCP."""

from src.common.mcp import get_mcp_tools, add_mcp_server, get_all_mcp_tools, MCP_SERVERS


async def test_get_mcp_tools():
    """Test get MCP tools."""

    new_config = {
        "url": "https://new.example.com/mcp",
        "transport": "streamable_http",
    }

    add_mcp_server("new_server", new_config)
    assert "new_server" in MCP_SERVERS

    all_tools = await get_all_mcp_tools()
    print(f"Got {len(all_tools)} tools")
    all_tools_sep = []
    for server_name in MCP_SERVERS.keys():
        tools = await get_mcp_tools(server_name)
        print(f"Got {len(tools)} tools from {server_name}")
        all_tools_sep.extend(tools)

    assert len(all_tools) == len(all_tools_sep), "All tools should be separated"


if __name__ == "__main__":
    import asyncio
    asyncio.run(test_get_mcp_tools())

```

Result:

```
Got 6 tools
Got 3 tools from deepwiki
Got 3 tools from new_server
```